### PR TITLE
Remove macos dependent emulator code

### DIFF
--- a/src/runner/utils/device/AndroidEmulator.js
+++ b/src/runner/utils/device/AndroidEmulator.js
@@ -14,7 +14,7 @@ const delay = require('../delay');
 const log = require('../log');
 
 const TAG = 'PIXELS_CATCHER::UTIL_EMULATOR';
-const EMULATOR_CMD = `${process.env.HOME || ''}/Library/Android/sdk/emulator/emulator`;
+const EMULATOR_CMD = `emulator`;
 
 class AndroidEmulator implements DeviceInterface {
   _name: string;


### PR DESCRIPTION
The reasoning behind this is that the emulator should exist in $PATH already - react's own getting started guide asks you to set this up [https://facebook.github.io/react-native/docs/getting-started.html](https://facebook.github.io/react-native/docs/getting-started.html). It should therefore be expected that the developer has $PATH set up such that `emulator` can be reached from CLI.

Also, platform-specific code is a huge issue.

### Description of changes

### I did Exploratory testing:
- [X] android
- [ ] ios

### Can it be published to NPM?
- [ ] Breaking change
- [ ] Documentation is updated


Should not break anything given that the developer has followed good practice
