### PR TITLE
Fix the runner thinking that the emulator crashed.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "multer": "^1.4.1",
     "pixelmatch": "^4.0.2",
     "pngjs": "^3.3.3",
-    "react-native-save-view": "0.1.1"
+    "react-native-save-view": "0.1.2"
   },
   "peerDependencies": {
     "react-native": "0.*"

--- a/src/runner/utils/device/AndroidEmulator.js
+++ b/src/runner/utils/device/AndroidEmulator.js
@@ -98,6 +98,11 @@ class AndroidEmulator implements DeviceInterface {
     });
 
     result.stderr.on('data', (data: any): any => {
+      // Some data appears in stderr when running the emulator first time
+      const stringRepresentation = data.toString();
+      if (stringRepresentation.indexOf('.avd/snapshots/default_boot/ram.img') !== -1) {
+        return;
+      }
       log.e(TAG, `Failed to load emulator, stderr: ${data}`);
       process.exit(-1);
     });


### PR DESCRIPTION
### Description of changes


When running an emulator for the first time(as in CI, if you set up the emulator as part of the script),
it generates an error about the ram image not existing. This allows the test to continue even if the emulator complains about lacking ram.img

### I did Exploratory testing:
- [X] android
- [x] ~~ios~~

### Can it be published to NPM?
- [x] ~~Breaking change~~
- [x] ~~Documentation is updated~~
