### PR TITLE
Better handling errors when comparing images

### DIFF
--- a/src/runner/server/server.js
+++ b/src/runner/server/server.js
@@ -55,13 +55,19 @@ const postHandlers = {
     fs.writeFile(snapshotFile, base64, { encoding: 'base64' }, (writeError: any) => {
       if (!writeError) {
         log.v(TAG, 'File created');
-        const differentPixelsCount = compareImages(
-          snapshotFile,
-          expectedFile,
-          diffFile,
-        );
+        let differentPixelsCount = -1;
 
-        if (!differentPixelsCount) {
+        try {
+          differentPixelsCount = compareImages(
+            snapshotFile,
+            expectedFile,
+            diffFile,
+          );
+        } catch (err) {
+          log.e(TAG, `Failed to compare images: [${err.message}]`, err);
+        }
+
+        if (differentPixelsCount === 0) {
           log.v(TAG, 'All ok', differentPixelsCount);
           res.write(JSON.stringify({ result: 'OK' }));
         } else {


### PR DESCRIPTION
- Catch exception and report in case images do not match instead of throwing exception and stopping server. This allows to create all reference images and do not fail the runner

Fixes #31 

### Description of changes

### I did Exploratory testing:
- [x] android
- [x] ios

### Can it be published to NPM?
- [x] ~~Breaking change~~
- [x] ~~Documentation is updated~~
