### PR TITLE
canStopDevice property in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ PixelsCatcher: {
     }
   },
   logLevelel: number,
-  timeout: number
+  timeout: number,
+  canStopDevice: boolean
 }
 ```
 
@@ -111,6 +112,7 @@ where
   - `SHARED_CONFIGURATION`. In case more that one configurations exists, shared parameters can be moved here.
   - `logLevelel` - log levels: `e`, `w`, `i`, `d`, `v`. This corresponds to ERROR, WARN, INFO, DEBUG, VERBOSE
   - `timeout` - tests timeout, with default value 2500ms. If timeout is reached, tests will fail automatically
+  - `canStopDevice` [Optional] Boolean parameter that allows to stop device (used to restart simulator/emulator). If set to false, the runner will start a new simulator/emulator if none is started. If a simulator/emulator is already started, it will be used for tests. The runner will also stop the device after tests. **If set to "false" it is possible that wrong device will be used!**. Default value is `true`.
 
 Example for `package.json` configuration (or check
 [demo](https://github.com/rumax/PixelsCatcher/tree/master/demo) project):

--- a/demo/pixels-catcher.json
+++ b/demo/pixels-catcher.json
@@ -17,6 +17,14 @@
       ],
       "appFile": "./android/app/build/outputs/apk/debug/app-debug.apk"
     },
+    "test": {
+      "canStopDevice": false,
+      "deviceParams": [
+        "-no-audio",
+        "-no-snapshot"
+      ],
+      "appFile": "./android/app/build/outputs/apk/debug/app-debug.apk"
+    },
     "release": {
       "deviceParams": [
         "-no-audio",
@@ -33,6 +41,10 @@
     "dev": {},
     "debug": {
       "appFile": "./ios/build/Build/Products/Debug-iphonesimulator/demo.app"
+    },
+    "test": {
+      "appFile": "./ios/build/Build/Products/Debug-iphonesimulator/demo.app",
+      "canStopDevice": false
     },
     "debugIphone6": {
       "deviceName": "iPhone 6",

--- a/demo/run_android_test.sh
+++ b/demo/run_android_test.sh
@@ -7,4 +7,4 @@ rm -rf build .gradle/ app/build
 ./gradlew assembleDebug -DentryFile="indexSnapshot.js" -DbundleInDebug=true
 cd ..
 
-../node_modules/.bin/flow-node ../src/runner/cli.js android debug
+../node_modules/.bin/flow-node ../src/runner/cli.js android test

--- a/demo/run_ios_test.sh
+++ b/demo/run_ios_test.sh
@@ -21,5 +21,4 @@ xcrun xcodebuild \
 
 cd ..
 
-../node_modules/.bin/flow-node ../src/runner/cli.js ios debug || true
-../node_modules/.bin/flow-node ../src/runner/cli.js ios debugIphone6 || true
+../node_modules/.bin/flow-node ../src/runner/cli.js ios test

--- a/src/runner/cli.js
+++ b/src/runner/cli.js
@@ -58,14 +58,17 @@ log.setLevel(fullConfig.logLevelel);
 log.i(TAG, `Starting snapshots with [${configuration}] configuration for [${platform}]`);
 log.v(TAG, 'Using config\n' + JSON.stringify(config, null, 2));
 
-const getParamFromConfig = (paramName: string) =>
-  (config[configuration] || {})[paramName] || config[paramName];
+const getParamFromConfig = (paramName: string) => {
+  const value = (config[configuration] || {})[paramName];
+  return value !== undefined ? value : config[paramName];
+};
 
+const activityName = getParamFromConfig('activityName') || 'MainActivity';
+const appFile = getParamFromConfig('appFile');
+const canStopDevice = getParamFromConfig('canStopDevice');
 const deviceName = getParamFromConfig('deviceName');
 const deviceParams = getParamFromConfig('deviceParams');
 const isPhysicalDevice = getParamFromConfig('physicalDevice');
-const activityName = getParamFromConfig('activityName') || 'MainActivity';
-const appFile = getParamFromConfig('appFile');
 const packageName = getParamFromConfig('packageName');
 const snapshotsPath = getParamFromConfig('snapshotsPath');
 const timeout = fullConfig.timeout || 25 * 1000; // 25 sec is default
@@ -76,7 +79,12 @@ if (!deviceName) {
   process.exit(-1);
 }
 
-const device: DeviceInterface = getDevice(deviceName, platform, isPhysicalDevice);
+const device: DeviceInterface = getDevice(
+  deviceName,
+  platform,
+  isPhysicalDevice,
+  canStopDevice,
+);
 
 const DEV_MODE = !appFile;
 
@@ -88,7 +96,8 @@ log.i(TAG, `Using config:
   - deviceName: [${deviceName}]
   - deviceParams: [${deviceParams}]
   - packageName: [${packageName}]
-  - snapshotsPath: [${snapshotsPath}]`);
+  - snapshotsPath: [${snapshotsPath}]
+  - canStopDevice: [${canStopDevice}]`);
 
 if (!packageName) {
   log.e(TAG, 'Package name is required');

--- a/src/runner/utils/device/AndroidEmulator.js
+++ b/src/runner/utils/device/AndroidEmulator.js
@@ -19,8 +19,11 @@ const TAG = 'PIXELS_CATCHER::UTIL_EMULATOR';
 class AndroidEmulator implements DeviceInterface {
   _name: string;
 
-  constructor(name: string) {
+  _canStopDevice: boolean;
+
+  constructor(name: string, canStopDevice?: boolean) {
     this._name = name;
+    this._canStopDevice = Boolean(canStopDevice);
   }
 
 
@@ -73,8 +76,14 @@ class AndroidEmulator implements DeviceInterface {
     }
 
     if (this._getActiveDevice()) {
-      log.e(TAG, 'Other emulator already started, stopping it');
-      await this.stop();
+      log.e(TAG, 'Other emulator already started');
+      if (this._canStopDevice) {
+        log.e(TAG, 'Stopping emulator');
+        await this.stop();
+      } else {
+        log.d(TAG, 'Using active emulator');
+        return;
+      }
     }
 
     log.d(TAG, `Starting emulator [${this._name}]`);
@@ -121,6 +130,10 @@ class AndroidEmulator implements DeviceInterface {
 
 
   async stop() {
+    if (!this._canStopDevice) {
+      log.v(TAG, 'Stopping device is restricted in config');
+      return;
+    }
     log.v(TAG, 'Stopping active device');
     try {
       exec(`adb -s ${this._getActiveDevice()} emu kill;`);

--- a/src/runner/utils/device/AndroidEmulator.js
+++ b/src/runner/utils/device/AndroidEmulator.js
@@ -106,11 +106,11 @@ class AndroidEmulator implements DeviceInterface {
       log.v(TAG, `on close: child process exited with code ${code}`);
     });
 
-    let tryCnt = 30;
+    let tryCnt = 60 * 2 / 5; // 2 minutes with 5000 delay
 
     while (--tryCnt >= 0 && !deviceBooted) {
       log.v(TAG, 'awaiting when device is booted');
-      await delay(1000);
+      await delay(5000);
     }
 
     if (!deviceBooted) {

--- a/src/runner/utils/device/DeviceInterface.js
+++ b/src/runner/utils/device/DeviceInterface.js
@@ -9,7 +9,7 @@
 export type StartParamsType = Array<string>;
 
 export interface DeviceInterface {
-  constructor(deviceName: string): void,
+  constructor(deviceName: string, canStopDevice?: boolean): void,
 
   start(params: StartParamsType): Promise<void>,
 

--- a/src/runner/utils/device/IosSimulator.js
+++ b/src/runner/utils/device/IosSimulator.js
@@ -25,8 +25,11 @@ type DeviceType = {
 class IOSSimulator implements DeviceInterface {
   _name: string;
 
-  constructor(name: string) {
+  _canStopDevice: boolean;
+
+  constructor(name: string, canStopDevice?: boolean) {
     this._name = name;
+    this._canStopDevice = Boolean(canStopDevice);
   }
 
 
@@ -166,6 +169,11 @@ class IOSSimulator implements DeviceInterface {
 
 
   async stop() {
+    if (!this._canStopDevice) {
+      log.v(TAG, 'Stopping device is restricted in config');
+      return;
+    }
+
     log.v(TAG, 'Stopping all devices');
 
     exec('osascript -e \'tell application "iOS Simulator" to quit\'');

--- a/src/runner/utils/device/__tests__/__snapshots__/AndroidEmulator.js.snap
+++ b/src/runner/utils/device/__tests__/__snapshots__/AndroidEmulator.js.snap
@@ -2,6 +2,7 @@
 
 exports[`AndroidEmulator initialise emulator 1`] = `
 AndroidEmulator {
+  "_canStopDevice": false,
   "_name": "emulator_name",
 }
 `;

--- a/src/runner/utils/device/deviceProvider.js
+++ b/src/runner/utils/device/deviceProvider.js
@@ -18,15 +18,16 @@ module.exports = (
   name: string,
   platform: string,
   isPhysicalDevice?: boolean,
+  canStopDevice?: boolean = true,
 ): DeviceInterface => {
   if (platform === 'android') {
     return isPhysicalDevice
       ? new AndroidDevice(name)
-      : new AndroidEmulator(name);
+      : new AndroidEmulator(name, canStopDevice);
   }
 
   if (!isPhysicalDevice) {
-    return new IosSimulator(name);
+    return new IosSimulator(name, canStopDevice);
   }
 
   log.e(TAG, 'iOS devices are not supported yet');


### PR DESCRIPTION
### Description of changes
Allows to keep the device running that reduces some testing time that is used to start/stop device

### I did Exploratory testing:
- [x] android
- [x] ios

### Can it be published to NPM?
- [x] ~~Breaking change~~
- [x] Documentation is updated
