### PR TITLE
Demo project: Use System.getenv insted of System.getProperty

### DIFF
--- a/demo/android/app/build.gradle
+++ b/demo/android/app/build.gradle
@@ -76,8 +76,8 @@ import com.android.build.OutputFile
  */
 
 project.ext.react = [
-    entryFile: System.getProperty("entryFile") ?: "index.js",
-    bundleInDebug: System.getProperty("bundleInDebug") ? System.getProperty("bundleInDebug").toBoolean() : false,
+    entryFile: System.getenv('ENTRY_FILE') ?: "index.js",
+    bundleInDebug: System.getenv("BUNDLE_IN_DEBUG") ? System.getenv("BUNDLE_IN_DEBUG").toBoolean() : false,
     enableHermes: false,  // clean and rebuild if changing
 ]
 

--- a/demo/ios/Podfile.lock
+++ b/demo/ios/Podfile.lock
@@ -331,8 +331,8 @@ SPEC CHECKSUMS:
   React-jsi: 32285a21b1b24c36060493ed3057a34677d58d09
   React-jsiexecutor: 8909917ff7d8f21a57e443a866fd8d4560e50c65
   React-jsinspector: 111d7d342b07a904c400592e02a2b958f1098b60
-  react-native-save-view: 327fb46c71e8785a5ec05500ec40b782d5456717
-  react-native-webview: e800df5dd1a0f3555fd543ebf7d881a9014851f2
+  react-native-save-view: 02d9af9d21a226632466e867053c3ce956f5d8f6
+  react-native-webview: 4dbc1d2a4a6b9c5e9e723c62651917aa2b5e579e
   React-RCTActionSheet: 89b037c0fb7d2671607cb645760164e7e0c013f6
   React-RCTAnimation: e3cefa93c38c004c318f7ec04b883eb14b8b8235
   React-RCTBlob: d26ac0e313fbf14e7203473fd593ccaaeee8329e

--- a/demo/package.json
+++ b/demo/package.json
@@ -24,7 +24,7 @@
     "eslint": "^6.5.1",
     "jest": "^24.9.0",
     "metro-react-native-babel-preset": "^0.56.0",
-    "pixels-catcher": "^0.5.2",
+    "pixels-catcher": "^0.5.3",
     "react-native-webview": "^7.4.1",
     "react-test-renderer": "16.9.0"
   },

--- a/demo/run_android_debug.sh
+++ b/demo/run_android_debug.sh
@@ -2,9 +2,12 @@
 set -x
 set -e
 
+export ENTRY_FILE="indexSnapshot.js"
+export BUNDLE_IN_DEBUG="true"
+
 cd android
 rm -rf build .gradle/ app/build
-./gradlew assembleDebug -DentryFile="indexSnapshot.js" -DbundleInDebug=true
+./gradlew assembleDebug
 cd ..
 
 ./node_modules/.bin/pixels-catcher android debug

--- a/demo/run_android_release.sh
+++ b/demo/run_android_release.sh
@@ -2,9 +2,11 @@
 set -x
 set -e
 
+export ENTRY_FILE="indexSnapshot.js"
+
 cd android
 rm -rf build .gradle/ app/build
-./gradlew assembleRelease -DentryFile="indexSnapshot.js"
+./gradlew assembleRelease
 cd ..
 
 ./node_modules/.bin/pixels-catcher android release

--- a/demo/run_android_test.sh
+++ b/demo/run_android_test.sh
@@ -2,9 +2,12 @@
 set -x
 set -e
 
+export ENTRY_FILE="indexSnapshot.js"
+export BUNDLE_IN_DEBUG="true"
+
 cd android
 rm -rf build .gradle/ app/build
-./gradlew assembleDebug -DentryFile="indexSnapshot.js" -DbundleInDebug=true
+./gradlew assembleDebug
 cd ..
 
 ../node_modules/.bin/flow-node ../src/runner/cli.js android test


### PR DESCRIPTION
### Description of changes
- Demo project: Use System.getenv insted of System.getProperty
- The change is also proposed to facebook/react-native project in PR

### I did Exploratory testing:
- [x] android
- [x] ~~ios~~

### Can it be published to NPM?
- [x] ~~Breaking change~~
- [x] ~~Documentation is updated~~
