### PR TITLE
iOS: Fix open of the simulator

### DIFF
--- a/demo/ios/Podfile.lock
+++ b/demo/ios/Podfile.lock
@@ -331,8 +331,8 @@ SPEC CHECKSUMS:
   React-jsi: 32285a21b1b24c36060493ed3057a34677d58d09
   React-jsiexecutor: 8909917ff7d8f21a57e443a866fd8d4560e50c65
   React-jsinspector: 111d7d342b07a904c400592e02a2b958f1098b60
-  react-native-save-view: 327fb46c71e8785a5ec05500ec40b782d5456717
-  react-native-webview: e800df5dd1a0f3555fd543ebf7d881a9014851f2
+  react-native-save-view: 02d9af9d21a226632466e867053c3ce956f5d8f6
+  react-native-webview: 4dbc1d2a4a6b9c5e9e723c62651917aa2b5e579e
   React-RCTActionSheet: 89b037c0fb7d2671607cb645760164e7e0c013f6
   React-RCTAnimation: e3cefa93c38c004c318f7ec04b883eb14b8b8235
   React-RCTBlob: d26ac0e313fbf14e7203473fd593ccaaeee8329e

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pixels-catcher",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "UI snpashot testing for React Native",
   "main": "lib/client/index.js",
   "scripts": {

--- a/src/runner/utils/device/IosSimulator.js
+++ b/src/runner/utils/device/IosSimulator.js
@@ -120,7 +120,12 @@ class IOSSimulator implements DeviceInterface {
 
 
   async _open(uid: string) {
-    exec(`open -a Simulator --args -CurrentDeviceUDID ${uid}`);
+    const activeXcode = exec('xcode-select -p').trim();
+    log.v(TAG, `Active Xcode: ${activeXcode}`);
+    const simulatorApp = `${activeXcode}/Applications/Simulator.app`;
+    log.v(TAG, `starting ${simulatorApp}`);
+    exec(`open -a ${simulatorApp} --args -CurrentDeviceUDID ${uid}`);
+    log.v(TAG, 'started');
   }
 
 


### PR DESCRIPTION
- Not Simulator is available as an application which leads to crash during tests start
- It is possible that other Xcode versions are used
- This fix includes:
   * check of the Xcode location
   * use simulator from active Xcode
- Closes #42 
- New version `v0.5.5`

### Description of changes

### I did Exploratory testing:
- [x] ~~android~~
- [x] ios

### Can it be published to NPM?
- [x] ~~Breaking change~~
- [x] ~~Documentation is updated~~
