### PR TITLE
Adnroid: activityName config requires full name

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,20 +104,20 @@ where
 
   - `PLATFORM` can be `android` or `ios`
   - `CONFIGURATION` is a configuration with the following properties:
-    - `activityName` - Activity name, example: MainActivity.
-    - `appFile` - [Optional] Path to apk file on adroid or app folder on iOS,
+    * `activityName` - (*Android only*) Activity name, example: com.demo.MainActivity.
+    * `appFile` - (*Optional*) Path to apk file on adroid or app folder on iOS,
       example: ./app/build/outputs/apk/debug/app-debug.apk
-    - `deviceName` - Device name, for example emulator: Nexus_5X or iOS:
+    * `deviceName` - Device name, for example emulator: Nexus_5X or iOS:
       iPhone 8 Plus
-    - `deviceParams` - [Optional] Array of emulator params like -no-audio,
+    * `deviceParams` - (*Optional*) Array of emulator params like -no-audio,
       -no-snapshot, -no-window, etc.
-    - `physicalDevice` - [Optional] Boolean value that indicates if real device should be used (*iOS devices are not supported yet*)
-    - `packageName` -
-        **Android** package name, example: *com.rumax.pixelscatcher.testapp**.
-      **iOS** bundle identifier, example: *org.reactjs.native.example.demo*
-    - `snapshotsPath` - Path to snapshots, example: ./snapshotsImages
-    - `port` - Server port. Default value is `3000`
-    - `locale` - Locale to be used, for example `uk-UA`, `nl-NL`, etc. At this moment supported only on iOS simulators. ([Pull request welcome](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests) for android implementation)
+    * `physicalDevice` - (*Optional*) Boolean value that indicates if real device should be used (*iOS devices are not supported yet*)
+    * `packageName` -
+        **Android** package name, example: *com.demo**.
+        **iOS** bundle identifier, example: *org.reactjs.native.example.demo*
+    * `snapshotsPath` - Path to snapshots, example: ./snapshotsImages
+    * `port` - Server port. Default value is `3000`
+    * `locale` - Locale to be used, for example `uk-UA`, `nl-NL`, etc. At this moment supported only on iOS simulators. ([Pull request welcome](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests) for android implementation)
   - `SHARED_CONFIGURATION`. In case more that one configurations exists, shared parameters can be moved here.
   - `logLevelel` - log levels: `e`, `w`, `i`, `d`, `v`. This corresponds to ERROR, WARN, INFO, DEBUG, VERBOSE
   - `timeout` - tests timeout, with default value 2500ms. If timeout is reached, tests will fail automatically

--- a/demo/pixels-catcher.json
+++ b/demo/pixels-catcher.json
@@ -1,6 +1,6 @@
 {
   "android": {
-    "activityName": "MainActivity",
+    "activityName": "com.demo.MainActivity",
     "deviceName": "Nexus_5X",
     "packageName": "com.demo",
     "snapshotsPath": "./snapshots/android",

--- a/src/runner/utils/device/AndroidEmulator.js
+++ b/src/runner/utils/device/AndroidEmulator.js
@@ -200,7 +200,7 @@ class AndroidEmulator implements DeviceInterface {
   startApp(packageName: string, activityName: string) {
     log.v(TAG, `Starting application [${packageName}]`);
 
-    const cmd = `adb shell am start -n ${packageName}/${packageName}.${activityName}`;
+    const cmd = `adb shell am start -n ${packageName}/${activityName}`;
     const result = exec(cmd);
 
     if (result.indexOf('does not exist') >= 0 || result.indexOf('Error') >= 0) {


### PR DESCRIPTION
In Android, you may add suffix to the applicationId of the app in the debugging environment
See: https://developer.android.com/studio/build/build-variants#build-types

For example, it can be io.mrtry.app.debug for a debugging app and io.mrtry.app for a production app.

In this case, you need to specify the following to launch the app from adb.
Debug environment: $ am start -n io.mrtry.app.debug/.activity.MainActivity
Production environment: $ am start -n io.mrtry.app/.activity.MainActivity

But the current argument for adb looks like this
$ am start -n /.

That commit fixes that issue by requiring full activityName instead of concatination with packageName

Fixes #59

### Description of changes

### I did Exploratory testing:
- [x] android
- [x] ios

### Can it be published to NPM?
- [x] Breaking change
- [x] Documentation is updated
