### PR TITLE
allow making new directories with subdirectories

### DIFF
--- a/src/runner/server/server.js
+++ b/src/runner/server/server.js
@@ -25,7 +25,7 @@ let nextSocketId = 0;
 
 const mkDir = (dirName: string) => {
   if (!fs.existsSync(dirName)) {
-    fs.mkdirSync(dirName);
+    fs.mkdirSync(dirName, { recursive: true });
   }
 };
 


### PR DESCRIPTION
### Description of changes
When you are using fs.mkdir or fs.mkdirSync, while passing the path like folder1/folder2/folder3, folder1 and folder2 must exist otherwise you will get the ENOENT error, recursive flag solves this issue

### I did Exploratory testing:
- [x] android
- [x] ios

### Can it be published to NPM?
- [ ] Breaking change
- [ ] Documentation is updated
