### PR TITLE
add react-native-navigation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,34 @@ interactions ([InteractionManager](https://reactnative.dev/docs/interactionmanag
   * register animations by creating an interaction 'handle' and clearing it upon completion
   * override `componentDidMount` of the `Snapshot` and call `onReady` whenever you need it. `WebViewTest` in [demo](https://github.com/rumax/react-native-PixelsCatcher/blob/master/demo/indexSnapshot.js) project for more details
 
+### React Native Navigation support
+
+Register your component and `setRoot` in `rnnSetup`
+
+```
+runSnapshots(appName, {
+  rnnSetup: snapshot => {
+    Navigation.registerComponent(appName, () => snapshot)
+
+    Navigation.events().registerAppLaunchedListener(async () => {
+      Navigation.setRoot({
+        root: {
+          stack: {
+            children: [
+              {
+                component: {
+                  name: appName,
+                },
+              },
+            ],
+          },
+        },
+      })
+    })
+  },
+})
+```
+
 ### Configuration
 
 There are two options to define config:

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -18,14 +18,25 @@ export const registerSnapshot = require('./snapshotsManager').registerSnapshot;
 
 const TAG = 'PIXELS_CATCHER::APP::SNAPSHOT';
 
-type ConfigType = { baseUrl?: string };
+type ConfigType = {
+  baseUrl?: string,
+  /**
+   * Callback for react-native-navigation
+   * @param snapshot Current snapshot
+   */
+  rnnSetup?: (snapshot: SnapshotsContainer) => void,
+};
 
 export const runSnapshots = (appName: string, config: ConfigType = {}) => {
   log.i(TAG, `Run snapshots for ${appName}`);
   log.i(TAG, `Config is:\n ${JSON.stringify(config, null, 2)}`);
-  const { baseUrl } = config;
+  const { baseUrl, rnnSetup } = config;
   if (baseUrl) {
     network.setBaseUrl(baseUrl);
   }
-  AppRegistry.registerComponent(appName, () => SnapshotsContainer);
+  if (rnnSetup) {
+    rnnSetup(SnapshotsContainer);
+  } else {
+    AppRegistry.registerComponent(appName, () => SnapshotsContainer);
+  }
 };


### PR DESCRIPTION
### Description of changes
When using React Native Navigation AppRegistry stops working and you need to manually register all your screens and then operate them through setting the root screen, pushing etc. This pr gives an opportunity to use rnn through rnnSetup field in config param passed to runSnapshots function

### I did Exploratory testing:
- [x] android
- [x] ios

### Can it be published to NPM?
- [ ] Breaking change
- [x] Documentation is updated
