### PR TITLE
add react-native-navigation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,35 @@ interactions ([InteractionManager](https://reactnative.dev/docs/interactionmanag
   * register animations by creating an interaction 'handle' and clearing it upon completion
   * override `componentDidMount` of the `Snapshot` and call `onReady` whenever you need it. `WebViewTest` in [demo](https://github.com/rumax/react-native-PixelsCatcher/blob/master/demo/indexSnapshot.js) project for more details
 
+### React Native Navigation support
+
+Register your component and `Navigation.setRoot` using `registerComponent`
+property in `runSnapshots`:
+
+```
+runSnapshots(appName, {
+  registerComponent: snapshot => {
+    Navigation.registerComponent(appName, () => snapshot)
+
+    Navigation.events().registerAppLaunchedListener(async () => {
+      Navigation.setRoot({
+        root: {
+          stack: {
+            children: [
+              {
+                component: {
+                  name: appName,
+                },
+              },
+            ],
+          },
+        },
+      })
+    })
+  },
+})
+```
+
 ### Configuration
 
 There are two options to define config:

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -18,14 +18,26 @@ export const registerSnapshot = require('./snapshotsManager').registerSnapshot;
 
 const TAG = 'PIXELS_CATCHER::APP::SNAPSHOT';
 
-type ConfigType = { baseUrl?: string };
+type ConfigType = {
+  baseUrl?: string,
+  /**
+   * Callback to override AppRegistry.registerComponent with custom
+   * implementation. Can be used for projects with react-native-navigation
+   * @param snapshot Current snapshot
+   */
+  registerComponent?: (snapshot: typeof SnapshotsContainer) => void,
+};
 
 export const runSnapshots = (appName: string, config: ConfigType = {}) => {
   log.i(TAG, `Run snapshots for ${appName}`);
   log.i(TAG, `Config is:\n ${JSON.stringify(config, null, 2)}`);
-  const { baseUrl } = config;
-  if (baseUrl) {
-    network.setBaseUrl(baseUrl);
+
+  if (config.baseUrl) {
+    network.setBaseUrl(config.baseUrl);
   }
-  AppRegistry.registerComponent(appName, () => SnapshotsContainer);
+  if (config.registerComponent) {
+    config.registerComponent(SnapshotsContainer);
+  } else {
+    AppRegistry.registerComponent(appName, () => SnapshotsContainer);
+  }
 };


### PR DESCRIPTION
### Description of changes
When using React Native Navigation AppRegistry stops working and you need to manually register all your screens and then operate them through setting the root screen, pushing etc. This pr gives an opportunity to use rnn through rnnSetup field in config param passed to runSnapshots function

### I did Exploratory testing:
- [x] android
- [x] ios

### Can it be published to NPM?
- [ ] Breaking change
- [x] Documentation is updated

Closes #63 