### PR TITLE
fix: Fix start of android emulator API > 30

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -45,6 +45,7 @@
         "no-await-in-loop": 0,
         "max-classes-per-file": 0,
         "global-require": 0,
-        "react/jsx-filename-extension": 0
+        "react/jsx-filename-extension": 0,
+        "@typescript-eslint/no-unused-vars": "warn"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pixels-catcher",
-  "version": "0.12.7",
+  "version": "0.12.8",
   "description": "UI snapshot testing for React Native",
   "main": "lib/client/index.js",
   "scripts": {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -4,6 +4,7 @@
 * This source code is licensed under the MIT license found in the
 * LICENSE file in the root directory of this source tree.
 */
+import React from 'react';
 import { AppRegistry } from 'react-native';
 
 import log from './utils/log';

--- a/src/client/utils/log.ts
+++ b/src/client/utils/log.ts
@@ -7,8 +7,7 @@
 import network from './network';
 
 const consoleLog = global.console && global.console.log
-  // eslint-disable-next-line no-unused-vars
-  ? global.console.log : (...args: any) => {};
+  ? global.console.log : () => {};
 
 type LogLevelType = 'v' | 'd' | 'i' | 'w' | 'e';
 


### PR DESCRIPTION
### Description of changes
With API > 30 android emulator reports some warnings that are treated as
errors. Therefore ignoring them to let the emulator start
Fixes #82

### I did Exploratory testing:
- [x] android
- [x] ios

### Can it be published to NPM?
- [x] ~~Breaking change~~
- [x] ~~Documentation is updated~~
