### PR TITLE
fix: Do not update SnapshotsContainer on props change

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 variables:
   MAC_RUNNER_IMAGE: 'macos-12'
   NODE_VERSION: '16.x'
-  XCODE_VERSION: '14.0'
+  XCODE_VERSION: '14.2'
 
 trigger:
   branches:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,6 @@
 variables:
   MAC_RUNNER_IMAGE: 'macos-12'
-  NODE_VERSION: '16.x'
+  NODE_VERSION: '19.x'
   XCODE_VERSION: '14.2'
 
 trigger:

--- a/demo/indexSnapshot.js
+++ b/demo/indexSnapshot.js
@@ -16,22 +16,26 @@ const baseUrl = Platform.select({
 });
 const useFailedTest = false;
 
-registerSnapshot(
-  class SnapshotClass extends Snapshot {
-    static snapshotName = 'AppSnapshot';
+const appSnapshot = false;
 
-    componentDidMount() {
-      setTimeout(() => {
-        // delay for rendering images
-        this.props.onReady();
-      }, 1000);
-    }
+if (appSnapshot) {
+  registerSnapshot(
+    class SnapshotClass extends Snapshot {
+      static snapshotName = 'AppSnapshot';
 
-    renderContent() {
-      return <App />;
-    }
-  },
-);
+      componentDidMount() {
+        setTimeout(() => {
+          // delay for rendering images
+          this.props.onReady();
+        }, 1000);
+      }
+
+      renderContent() {
+        return <App />;
+      }
+    },
+  );
+}
 
 registerSnapshot(
   class SnapshotClass extends Snapshot {

--- a/demo/indexSnapshot.js
+++ b/demo/indexSnapshot.js
@@ -69,32 +69,36 @@ registerSnapshot(
   },
 );
 
-registerSnapshot(
-  class SnapshotClass extends Snapshot {
-    static snapshotName = 'WebViewTest';
+const useWebView = false;
 
-    componentDidMount() {
-      // override default componentDidMount from Snapshot to delay it
-      // until WebView is loaded. onLoad from WebView is used
-    }
+if (useWebView) {
+  registerSnapshot(
+    class SnapshotClass extends Snapshot {
+      static snapshotName = 'WebViewTest';
 
-    renderContent() {
-      return (
-        <WebView
-          source={{
-            uri: 'https://raw.githubusercontent.com/rumax/react-native-PixelsCatcher/master/CONTRIBUTING.md',
-          }}
-          style={{ flex: 1, marginTop: 20 }}
-          onLoad={() => {
-            setTimeout(() => {
-              this.props.onReady();
-            }, 50);
-          }}
-        />
-      );
-    }
-  },
-);
+      componentDidMount() {
+        // override default componentDidMount from Snapshot to delay it
+        // until WebView is loaded. onLoad from WebView is used
+      }
+
+      renderContent() {
+        return (
+          <WebView
+            source={{
+              uri: 'https://raw.githubusercontent.com/rumax/react-native-PixelsCatcher/master/CONTRIBUTING.md',
+            }}
+            style={{ flex: 1, marginTop: 20 }}
+            onLoad={() => {
+              setTimeout(() => {
+                this.props.onReady();
+              }, 50);
+            }}
+          />
+        );
+      }
+    },
+  );
+}
 
 registerSnapshot(
   class SnapshotClass extends Snapshot {

--- a/demo/indexSnapshot.js
+++ b/demo/indexSnapshot.js
@@ -24,7 +24,7 @@ registerSnapshot(
       setTimeout(() => {
         // delay for rendering images
         this.props.onReady();
-      }, 500);
+      }, 1000);
     }
 
     renderContent() {

--- a/demo/ios/Podfile.lock
+++ b/demo/ios/Podfile.lock
@@ -239,7 +239,7 @@ PODS:
   - React-jsinspector (0.70.0)
   - React-logger (0.70.0):
     - glog
-  - react-native-safe-area-context (4.3.3):
+  - react-native-safe-area-context (4.5.0):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -247,7 +247,7 @@ PODS:
     - ReactCommon/turbomodule/core
   - react-native-save-view (0.2.3):
     - React
-  - react-native-webview (11.23.1):
+  - react-native-webview (11.26.1):
     - React-Core
   - React-perflogger (0.70.0)
   - React-RCTActionSheet (0.70.0):
@@ -315,9 +315,9 @@ PODS:
     - React-jsi (= 0.70.0)
     - React-logger (= 0.70.0)
     - React-perflogger (= 0.70.0)
-  - RNGestureHandler (2.6.0):
+  - RNGestureHandler (2.9.0):
     - React-Core
-  - RNScreens (3.17.0):
+  - RNScreens (3.19.0):
     - React-Core
     - React-RCTImage
   - Yoga (1.14.0)
@@ -474,9 +474,9 @@ SPEC CHECKSUMS:
   React-jsiexecutor: be588b7abbea4f1d03840bc675d68d99380e5bf3
   React-jsinspector: bd839d6c2c28e49fe1373f055735d2abecbd6cf3
   React-logger: 48d82b9be8e44d86668de4453fdb60255516388b
-  react-native-safe-area-context: b456e1c40ec86f5593d58b275bd0e9603169daca
+  react-native-safe-area-context: 39c2d8be3328df5d437ac1700f4f3a4f75716acc
   react-native-save-view: 327fb46c71e8785a5ec05500ec40b782d5456717
-  react-native-webview: d33e2db8925d090871ffeb232dfa50cb3a727581
+  react-native-webview: 9f111dfbcfc826084d6c507f569e5e03342ee1c1
   React-perflogger: 77947e49d84e31eb87d454d4ef327542dcfeaebc
   React-RCTActionSheet: 9f5fd6c1666c1a834ab7f45a452ed08b1de44eb8
   React-RCTAnimation: 6fd3db6ca387c8432fd6a26428e940a081bcb476
@@ -489,8 +489,8 @@ SPEC CHECKSUMS:
   React-RCTVibration: 5499b77c0fd57f346a5f0b36bb79fdb020d17d3e
   React-runtimeexecutor: 80c195ffcafb190f531fdc849dc2d19cb4bb2b34
   ReactCommon: de55f940495d7bf87b5d7bf55b5b15cdd50d7d7b
-  RNGestureHandler: 920eb17f5b1e15dae6e5ed1904045f8f90e0b11e
-  RNScreens: 0df01424e9e0ed7827200d6ed1087ddd06c493f9
+  RNGestureHandler: 071d7a9ad81e8b83fe7663b303d132406a7d8f39
+  RNScreens: ea4cd3a853063cda19a4e3c28d2e52180c80f4eb
   Yoga: 82c9e8f652789f67d98bed5aef9d6653f71b04a9
 
 PODFILE CHECKSUM: 93a25e00c74f6d6f430340e64d62a86baa1a1bae

--- a/demo/run_ios_debug.sh
+++ b/demo/run_ios_debug.sh
@@ -14,7 +14,7 @@ xcrun xcodebuild \
   -scheme demo \
   -workspace demo.xcworkspace \
   -configuration Debug \
-  -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.0' \
+  -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.2' \
   -derivedDataPath $BUILD_PATH \
   ENTRY_FILE="indexSnapshot.js" \
   build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pixels-catcher",
-  "version": "0.12.9",
+  "version": "0.13.0",
   "description": "UI snapshot testing for React Native",
   "main": "lib/client/index.js",
   "scripts": {

--- a/src/client/SnapshotsContainer.tsx
+++ b/src/client/SnapshotsContainer.tsx
@@ -19,12 +19,14 @@ import type Snapshot from './Snapshot';
 
 const TAG = 'PIXELS_CATCHER::APP::SNAPSHOTS_CONTAINER';
 
+type NoProps = Record<never, never>;
+
 type State = {
   isReady: boolean,
   ActiveSnapshot: typeof Snapshot | null,
 };
 
-export default class SnapshotsContainer extends Component<Record<never, never>, State> {
+export default class SnapshotsContainer extends Component<NoProps, State> {
   _viewRef: any;
 
   _testStartedAt: number = new Date().getTime();
@@ -38,6 +40,14 @@ export default class SnapshotsContainer extends Component<Record<never, never>, 
       ActiveSnapshot: null,
       isReady: false,
     };
+  }
+
+  shouldComponentUpdate(
+    nextProps: NoProps,
+    nextState: Readonly<State>,
+  ): boolean {
+    return this.state.ActiveSnapshot !== nextState.ActiveSnapshot
+      || this.state.isReady !== nextState.isReady;
   }
 
   componentDidMount(): void {

--- a/src/runner/server/server.ts
+++ b/src/runner/server/server.ts
@@ -25,8 +25,7 @@ let nextSocketId = 0;
 const mkDir = (directory: string, clean: boolean = false): void => {
   if (clean && fs.existsSync(directory)) {
     log.i(TAG, `Cleaning [${directory}]`);
-    // @ts-ignore: https://nodejs.org/api/fs.html#fs_fspromises_rmdir_path_options
-    fs.rmdirSync(directory, { recursive: true });
+    fs.rmSync(directory, { recursive: true });
   }
 
   if (!fs.existsSync(directory)) {


### PR DESCRIPTION
In case React native navigation is used (for example with getRootElement) and route params need to be updated, it results in re render of the SnapshotsContainer, which does not consume the propertis. Instead a child (UI test snapshot) should react on property change, which can be a use of useNavigation or useRoute hooks

### Description of changes

### I did Exploratory testing:
- [x] android
- [x] ios

### Can it be published to NPM?
- [x] ~~Breaking change~~
- [x] ~~Documentation is updated~~
