### PR TITLE
Fix case-sensitive matching of boot complete message

### DIFF
--- a/src/runner/utils/device/AndroidEmulator.ts
+++ b/src/runner/utils/device/AndroidEmulator.ts
@@ -113,7 +113,7 @@ class AndroidEmulator implements DeviceInterface {
 
     result.stdout.on('data', (data: any): any => {
       log.d(TAG, `stdout: ${data}`);
-      if (data.indexOf('boot completed') >= 0) {
+      if (data.toString().toLowerCase().includes('boot completed')) {
         deviceBooted = true;
       }
     });


### PR DESCRIPTION
### Description of changes
These changes introduce case-insensitive matching of the emulator's boot completed message in order to fix #94

### I did Exploratory testing:
- [x] android
- [ ] ios

### Can it be published to NPM?
- [ ] Breaking change
- [ ] Documentation is updated
